### PR TITLE
Enhance vehicle data model and seeding functionality

### DIFF
--- a/prisma/migrations/20250615210627_add_make_category_relation/migration.sql
+++ b/prisma/migrations/20250615210627_add_make_category_relation/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "_VehicleCategoryToVehicleMake" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_VehicleCategoryToVehicleMake_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_VehicleCategoryToVehicleMake_B_index" ON "_VehicleCategoryToVehicleMake"("B");
+
+-- AddForeignKey
+ALTER TABLE "_VehicleCategoryToVehicleMake" ADD CONSTRAINT "_VehicleCategoryToVehicleMake_A_fkey" FOREIGN KEY ("A") REFERENCES "VehicleCategory"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_VehicleCategoryToVehicleMake" ADD CONSTRAINT "_VehicleCategoryToVehicleMake_B_fkey" FOREIGN KEY ("B") REFERENCES "VehicleMake"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250615211014_add_make_category_relation/migration.sql
+++ b/prisma/migrations/20250615211014_add_make_category_relation/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_VehicleCategoryToVehicleMake` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `vehicleCategoryId` to the `VehicleMake` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_VehicleCategoryToVehicleMake" DROP CONSTRAINT "_VehicleCategoryToVehicleMake_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_VehicleCategoryToVehicleMake" DROP CONSTRAINT "_VehicleCategoryToVehicleMake_B_fkey";
+
+-- AlterTable
+ALTER TABLE "VehicleMake" ADD COLUMN     "vehicleCategoryId" INTEGER NOT NULL;
+
+-- DropTable
+DROP TABLE "_VehicleCategoryToVehicleMake";
+
+-- AddForeignKey
+ALTER TABLE "VehicleMake" ADD CONSTRAINT "VehicleMake_vehicleCategoryId_fkey" FOREIGN KEY ("vehicleCategoryId") REFERENCES "VehicleCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,6 +137,7 @@ model VehicleCategory {
   id           Int           @id @default(autoincrement())
   name         String
   publications Publication[]
+  makes        VehicleMake[]
 }
 
 model VehicleModel {
@@ -152,7 +153,9 @@ model VehicleModel {
 model VehicleMake {
   id            Int            @id @default(autoincrement())
   name          String         @unique
-  vehicleModels VehicleModel[]
+  vehicleCategoryId Int
+  vehicleCategory VehicleCategory @relation(fields: [vehicleCategoryId], references: [id])
 
-  publications Publication[]
+  vehicleModels VehicleModel[]
+  publications  Publication[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,152 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // Create Vehicle Categories
+  const categories = await Promise.all([
+    prisma.vehicleCategory.create({
+      data: {
+        name: 'Sedan',
+      },
+    }),
+    prisma.vehicleCategory.create({
+      data: {
+        name: 'SUV',
+      },
+    }),
+    prisma.vehicleCategory.create({
+      data: {
+        name: 'Pickup',
+      },
+    }),
+  ]);
+
+  // Create Vehicle Makes with their categories
+  const makes = await Promise.all([
+    prisma.vehicleMake.create({
+      data: {
+        name: 'Toyota',
+        vehicleCategoryId: categories[0].id,
+      },
+    }),
+    prisma.vehicleMake.create({
+      data: {
+        name: 'Ford',
+        vehicleCategoryId: categories[0].id,
+      },
+    }),
+    prisma.vehicleMake.create({
+      data: {
+        name: 'Volkswagen',
+        vehicleCategoryId: categories[0].id,
+      },
+    }),
+  ]);
+
+  // Create Vehicle Models
+  const models = await Promise.all([
+    // Toyota Models
+    prisma.vehicleModel.create({
+      data: {
+        name: 'Corolla',
+        vehicleMakeId: makes[0].id,
+      },
+    }),
+    prisma.vehicleModel.create({
+      data: {
+        name: 'RAV4',
+        vehicleMakeId: makes[0].id,
+      },
+    }),
+    // Ford Models
+    prisma.vehicleModel.create({
+      data: {
+        name: 'Focus',
+        vehicleMakeId: makes[1].id,
+      },
+    }),
+    prisma.vehicleModel.create({
+      data: {
+        name: 'Ranger',
+        vehicleMakeId: makes[1].id,
+      },
+    }),
+    // Volkswagen Models
+    prisma.vehicleModel.create({
+      data: {
+        name: 'Golf',
+        vehicleMakeId: makes[2].id,
+      },
+    }),
+    prisma.vehicleModel.create({
+      data: {
+        name: 'Tiguan',
+        vehicleMakeId: makes[2].id,
+      },
+    }),
+  ]);
+
+  // Create Vehicle Versions
+  await Promise.all([
+    // Toyota Corolla Versions
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'XEi',
+        vehicleModelId: models[0].id,
+      },
+    }),
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'XLi',
+        vehicleModelId: models[0].id,
+      },
+    }),
+    // Toyota RAV4 Versions
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'Limited',
+        vehicleModelId: models[1].id,
+      },
+    }),
+    // Ford Focus Versions
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'SE',
+        vehicleModelId: models[2].id,
+      },
+    }),
+    // Ford Ranger Versions
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'Wildtrak',
+        vehicleModelId: models[3].id,
+      },
+    }),
+    // Volkswagen Golf Versions
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'GTI',
+        vehicleModelId: models[4].id,
+      },
+    }),
+    // Volkswagen Tiguan Versions
+    prisma.vehicleVersion.create({
+      data: {
+        name: 'R-Line',
+        vehicleModelId: models[5].id,
+      },
+    }),
+  ]);
+
+  console.log('Seed data created successfully');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  }); 

--- a/src/repositories/VehicleMake.ts
+++ b/src/repositories/VehicleMake.ts
@@ -1,11 +1,36 @@
-import { BaseRepository } from "./base";
+import { BaseRepository, prisma } from "./base";
 import { Prisma } from "@prisma/client";
 
 class VehicleMakeRepository extends BaseRepository<
-  Prisma.VehicleMakeGetPayload<{}>
+  Prisma.VehicleMakeGetPayload<{
+    include: {
+      vehicleCategory: true;
+      vehicleModels: true;
+    };
+  }>
 > {
   constructor() {
     super("vehicleMake");
+  }
+
+  async findAll(where?: any) {
+    return await prisma.vehicleMake.findMany({
+      where,
+      include: {
+        vehicleCategory: true,
+        vehicleModels: true,
+      },
+    });
+  }
+
+  async findById(id: number) {
+    return await prisma.vehicleMake.findUnique({
+      where: { id },
+      include: {
+        vehicleCategory: true,
+        vehicleModels: true,
+      },
+    });
   }
 }
 

--- a/src/repositories/VehicleModel.ts
+++ b/src/repositories/VehicleModel.ts
@@ -1,11 +1,36 @@
-import { BaseRepository } from "./base";
+import { BaseRepository, prisma } from "./base";
 import { Prisma } from "@prisma/client";
 
 class VehicleModelRepository extends BaseRepository<
-  Prisma.VehicleModelGetPayload<{}>
+  Prisma.VehicleModelGetPayload<{
+    include: {
+      vehicleMake: true;
+      vehicleVersions: true;
+    };
+  }>
 > {
   constructor() {
     super("vehicleModel");
+  }
+
+  async findAll(where?: any) {
+    return await prisma.vehicleModel.findMany({
+      where,
+      include: {
+        vehicleMake: true,
+        vehicleVersions: true,
+      },
+    });
+  }
+
+  async findById(id: number) {
+    return await prisma.vehicleModel.findUnique({
+      where: { id },
+      include: {
+        vehicleMake: true,
+        vehicleVersions: true,
+      },
+    });
   }
 }
 

--- a/src/repositories/VehicleVersion.ts
+++ b/src/repositories/VehicleVersion.ts
@@ -1,11 +1,33 @@
-import { BaseRepository } from "./base";
+import { BaseRepository, prisma } from "./base";
 import { Prisma } from "@prisma/client";
 
 class VehicleVersionRepository extends BaseRepository<
-  Prisma.VehicleVersionGetPayload<{}>
+  Prisma.VehicleVersionGetPayload<{
+    include: {
+      vehicleModel: true;
+    };
+  }>
 > {
   constructor() {
     super("vehicleVersion");
+  }
+
+  async findAll(where?: any) {
+    return await prisma.vehicleVersion.findMany({
+      where,
+      include: {
+        vehicleModel: true,
+      },
+    });
+  }
+
+  async findById(id: number) {
+    return await prisma.vehicleVersion.findUnique({
+      where: { id },
+      include: {
+        vehicleModel: true,
+      },
+    });
   }
 }
 

--- a/src/services/vehicleDataService.ts
+++ b/src/services/vehicleDataService.ts
@@ -20,7 +20,7 @@ export class VehicleDataService implements IVehicleDataService {
   }
 
   async getMakesByCategory(categoryId: string): Promise<any[]> {
-    return await this.make.findAll({ categoryId: categoryId });
+    return await this.make.findAll({ vehicleCategoryId: parseInt(categoryId) });
   }
 
   async getMakeById(id: string): Promise<any> {
@@ -28,7 +28,7 @@ export class VehicleDataService implements IVehicleDataService {
   }
 
   async getModelsByMake(makeId: string): Promise<any[]> {
-    return await this.model.findAll({ makeId: makeId });
+    return await this.model.findAll({ vehicleMakeId: parseInt(makeId) });
   }
 
   async getModelById(id: string): Promise<any> {
@@ -36,7 +36,7 @@ export class VehicleDataService implements IVehicleDataService {
   }
 
   async getVersionsByModel(modelId: string): Promise<any[]> {
-    return await this.version.findAll({ modelId: modelId });
+    return await this.version.findAll({ vehicleModelId: parseInt(modelId) });
   }
 
   async getVersionById(id: string): Promise<any> {


### PR DESCRIPTION
- Updated the Prisma schema to establish a relationship between VehicleMake and VehicleCategory.
- Added a new seeding script to populate VehicleCategory, VehicleMake, VehicleModel, and VehicleVersion data.
- Refactored VehicleMake, VehicleModel, and VehicleVersion repositories to include related entities in queries.
- Adjusted vehicle data service methods to align with the new schema structure for fetching makes, models, and versions.